### PR TITLE
fix int size errors when compiling to JS

### DIFF
--- a/lib/src/number/lua_math.dart
+++ b/lib/src/number/lua_math.dart
@@ -1,3 +1,5 @@
+import '../stdlib/constants.dart' if (dart.library.html) '../stdlib/constants_js.dart';
+
 class LuaMath {
 
   static double floorDiv(double a, double b) {
@@ -44,6 +46,6 @@ class LuaMath {
 extension  LogicalRightShift on  int{
 
   int logicalRShift(int size){
-    return (this >> size) & 0x0FFFFFFFFFFFFFFF;
+    return (this >> size) & rShiftMask;
   }
 }

--- a/lib/src/stdlib/constants.dart
+++ b/lib/src/stdlib/constants.dart
@@ -1,0 +1,4 @@
+const int int64MinValue = -9223372036854775808;
+const int int64MaxValue = 9223372036854775807;
+
+const int rShiftMask = 0x0FFFFFFFFFFFFFFF;

--- a/lib/src/stdlib/constants_js.dart
+++ b/lib/src/stdlib/constants_js.dart
@@ -1,0 +1,5 @@
+//see: https://stackoverflow.com/a/60358200/85472
+const int int64MinValue = -9007199254740991;
+const int int64MaxValue = 9007199254740991; //for dart web is 2^53-1:
+
+const int rShiftMask = 0x0FFFFFFFFFFFFF;

--- a/lib/src/stdlib/math_lib.dart
+++ b/lib/src/stdlib/math_lib.dart
@@ -2,6 +2,8 @@
 import 'dart:math' as math;
 import '../../lua.dart';
 
+import 'constants.dart' if (dart.library.html) 'constants_js.dart';
+
 class MathLib{
 
   static const Map<String, DartFunction?> _mathLib = {
@@ -299,5 +301,4 @@ class MathLib{
 
 const rpd = math.pi/180;
 const double ln10 = 2.3025850929940456840179914546843642076011014886288;
-const int int64MinValue = -9223372036854775808;
-const int int64MaxValue = 9223372036854775807;
+


### PR DESCRIPTION
This attempts to fix #20 by using conditional imports to workaround the limitations set by the `dart2js` compiler.