### PR TITLE
Fix: Platform seperator raises UnsupportedError on web flutter

### DIFF
--- a/lib/src/stdlib/package_lib.dart
+++ b/lib/src/stdlib/package_lib.dart
@@ -18,7 +18,20 @@ const lua_exec_dir = "!";
 const lua_igmark = "-";
 
 class PackageLib {
-  static final lua_dirsep = Platform.pathSeparator;
+  static get lua_dirsep {
+    try {
+      return Platform.pathSeparator;
+    }
+    catch (e) {
+      if (e is UnsupportedError) {
+        // For flutter web
+        return "/";
+      }
+      else {
+        throw e;
+      }
+    }
+  }
 
   static const Map<String, DartFunction?> _pkgFuncs = {
     "searchpath": _pkgSearchPath,


### PR DESCRIPTION
fixes #28

Just catches the error and uses a fallback `/`.   
Prevents calling `ls.openLibs()` from crashing the app on web flutter.