### PR TITLE
Prevent error when taking the length of a string

### DIFF
--- a/lib/src/state/lua_state_impl.dart
+++ b/lib/src/state/lua_state_impl.dart
@@ -409,6 +409,7 @@ class LuaStateImpl implements LuaState, LuaVM {
     Object? val = _stack!.get(idx);
     if (val is String) {
       pushInteger(val.length);
+      return;
     }
 
     Object? mm = getMetamethod(val, val, "__len");


### PR DESCRIPTION
Currently, trying to measure the length of a string with #'abc' successfully adds the length to the stack, but doesn't break out of the function control flow, leaving the function to error.