### PR TITLE
Fix empty return statements not being emitted in bytecode.

### DIFF
--- a/lib/src/compiler/ast/block.dart
+++ b/lib/src/compiler/ast/block.dart
@@ -10,7 +10,7 @@ import 'stat.dart';
 // explist ::= exp {‘,’ exp}
 class Block extends Node {
   List<Stat> stats;
-  List<Exp> retExps;
+  List<Exp>? retExps;
 
   Block({required this.stats,required this.retExps});
 
@@ -26,9 +26,9 @@ class Block extends Node {
       }
       sb.write(']');
     }
-    if(retExps.isNotEmpty){
+    if(retExps != null){
       sb.write(',\nRetExps:[');
-      for(var exp in retExps){
+      for(var exp in retExps!){
         _expToStr(exp,sb);
       }
       sb.writeln(']');

--- a/lib/src/compiler/codegen/block_processor.dart
+++ b/lib/src/compiler/codegen/block_processor.dart
@@ -13,8 +13,8 @@ class BlockProcessor {
       StatProcessor.processStat(fi, stat);
     }
 
-    if (node.retExps.isNotEmpty) {
-      processRetStat(fi, node.retExps, node.lastLine);
+    if (node.retExps != null) {
+      processRetStat(fi, node.retExps!, node.lastLine);
     }
   }
 

--- a/lib/src/compiler/parser/block_parser.dart
+++ b/lib/src/compiler/parser/block_parser.dart
@@ -42,9 +42,9 @@ class BlockParser {
 
   // retstat ::= return [explist] [‘;’]
   // explist ::= exp {‘,’ exp}
-   static List<Exp> parseRetExps(Lexer lexer) {
+   static List<Exp>? parseRetExps(Lexer lexer) {
     if (lexer.LookAhead() != TokenKind.TOKEN_KW_RETURN) {
-      return List.empty();
+      return null;
     }
 
     lexer.nextToken();

--- a/test/block/empty_return.lua
+++ b/test/block/empty_return.lua
@@ -1,0 +1,10 @@
+x = true
+
+function empty_return()
+    if true then
+        return
+    end
+
+    -- Should not get here.
+    x = false
+end

--- a/test/block/empty_return_statement_test.dart
+++ b/test/block/empty_return_statement_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:lua_dardo/lua.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Empty return statement exits function early', () {
+    Directory.current = './test/block/';
+
+    final ls = LuaState.newState();
+    ls.openLibs();
+    ls.doFile("empty_return.lua");
+
+    ls.getGlobal("empty_return");
+    ls.pCall(0, 0, 1);
+
+    ls.getGlobal("x");
+    final result = ls.toBoolean(-1);
+    expect(result, true);
+  });
+}


### PR DESCRIPTION
Fixes issue https://github.com/arcticfox1919/LuaDardo/issues/34.

To determine if a block has a return statement, it was checking if `retExps` is empty. However, if an empty return statement was given (for example, in the code below), this would also be empty. Meaning the `RETURN` bytecode was never emitted.

```lua
function test()
    if true then
        return
    end
    print("should not get here")
end
```

This PR makes block `retExps` optional. This value being `null` means there was no return statement at the end of the block. It being an empty list, means an empty return statement.